### PR TITLE
Getting a clean build of the two examples (with caveat).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ output-%.pdf : output-%.svg
 	node ./svg2pdf.js $< $@
 
 output-%.svg : input-%.svg
-	node coarse.js $< $@
+	node ./coarse.js $< $@
 
 clean :
 	@rm -f ${OUTPUT_SVG} ${OUTPUT_PDF} *~

--- a/convert.js
+++ b/convert.js
@@ -1,6 +1,6 @@
 const parser = require('parse5');
 const styleParser = require('style-parser');
-const { getAttibute, getStyle } = require('./svg');
+const { getAttribute, getStyle } = require('./svg');
 
 // prewalk the DOM starting from `element`
 // and use `transformer` to replace nodes

--- a/svg.js
+++ b/svg.js
@@ -1,4 +1,5 @@
 // helpers
+const styleParser = require('style-parser');
 
 function getAttribute(element, attributeName) {
   let value;

--- a/svg2pdf.js
+++ b/svg2pdf.js
@@ -3,18 +3,16 @@
 const fs = require('fs')
 const PdfDoc = require('pdfkit')
 const svg2pdf = require('svg-to-pdfkit')
+const parser = require('parse5')
+const { getAttribute } = require('./svg')
 
 const inputFile = process.argv[2]
 const outputFile = process.argv[3]
-
 const svg = fs.readFileSync(inputFile, 'utf-8')
-
-const parser = require('parse5')
 const parsed = parser.parse(svg)
 // document -> html -> body -> svg
-const svgElement = parsed.childNodes[1].childNodes[1].childNodes[0]
+const svgElement = parsed.childNodes[0].childNodes[1].childNodes[0]
 
-const { getAttribute } = require('./svg')
 let width = getAttribute(svgElement, 'width')
 let height = getAttribute(svgElement, 'height')
 // remove px


### PR DESCRIPTION
-   Added some imports.
-   Using child 0 instead of child 1.

`make` now runs, but `output-small.pdf` is a full-size page instead of sized to fit the diagram.